### PR TITLE
GitHub action publish nuget

### DIFF
--- a/ProxySharp/ProxySharp.csproj
+++ b/ProxySharp/ProxySharp.csproj
@@ -12,6 +12,8 @@
     <PackageTags>proxy; server</PackageTags>
     <Version>2.0.0.0</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <AssemblyVersion>1.0.1.1</AssemblyVersion>
+	  <FileVersion>1.0.1.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProxySharp/ProxySharp.csproj
+++ b/ProxySharp/ProxySharp.csproj
@@ -12,8 +12,8 @@
     <PackageTags>proxy; server</PackageTags>
     <Version>2.0.0.0</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <AssemblyVersion>1.0.1.1</AssemblyVersion>
-	  <FileVersion>1.0.1.1</FileVersion>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Purpose :
- GitHub Action #22 
-  GitHub Action #7 

The push to nuget is not done if version is the same as one on nuget.org.
I was thinking setting version will be enough, but no.

## Details :
   - Update `ProxySharp.csproj`, manually change `AssemblyVersion` and `FileVersion` to `2.0.0.0`.

## Notes :
@m-henderson
PS : The action to nuget work only when merge to `master`, so its normal if `publish / deploy` is skipped on PR.