### PR TITLE
Add proxy filtering methods and update to version 2.0.1

### DIFF
--- a/ProxySharp.Tests/ProxyTests.cs
+++ b/ProxySharp.Tests/ProxyTests.cs
@@ -47,19 +47,6 @@ namespace ProxySharp.Tests
         }
 
         [Fact]
-        public void RenewFilteredProxiesTest()
-        {
-            var temp = Proxy.GetProxies();
-            Proxy.RenewQueue();
-            var temp2 = Proxy.GetUsedProxies();
-
-            for (int i = 0; i < temp.Count; i++)
-            {
-                Assert.NotEqual(temp[i], temp2[i]);
-            }
-        }
-
-        [Fact]
         public void GetIndexTest()
         {
             var proxy = Proxy.GetSingleProxy();

--- a/ProxySharp/Proxy.cs
+++ b/ProxySharp/Proxy.cs
@@ -25,7 +25,8 @@ namespace ProxySharp
         /// </summary>
         static Proxy()
         {
-            queue = Scrape.ScrapeProxies();
+            Scrape.GatherProxiesData();
+            queue = Scrape.ReturnAllProxy();
         }
 
         /// <summary>
@@ -81,36 +82,64 @@ namespace ProxySharp
         {
             usedProxies.AddRange(queue);
             queue.Clear();
-            queue = Scrape.ScrapeProxies();
+            Scrape.GatherProxiesData();
+            queue = Scrape.ReturnAllProxy();
         }
 
         /// <summary>
-        /// Clears the queue, then adds a fresh, filtered list of proxies based on the specified filters. Allows filtering by or excluding proxies. 
-        /// When "filterType = 2", the value1 and exclude1 are used for County and value2 and exclude2 for Port.
+        /// This method filters the proxies by country code. Include only or exclude proxies that match filter.
         /// </summary>
-        /// <param name="filterType">The type of filter : 0 = Coutry filter, 1 = Port fliter, 2 = Both filter</param>
-        /// <param name="value1">The two-letter code of the country to filter by (e.g., "US", "JP", "NZ") or the port to filter.</param>
-        /// <param name="exclude1">Set to true to exclude all proxies that match the filter; set to false to include only proxies that match the filter.</param>
-        /// <param name="value2">(Optional) The port to filter. Used only with "filterType = 2"</param>
-        /// <param name="exclude2">(Optional) Set to true to exclude all port that match the filter; set to false to include only proxies that match the filter. Used only with "filterType = 2"</param>
-        /// <example>
-        /// RenewFilteredProxies(0, "US", false);
-        /// // Renews a list of proxies from the United States only.
-        /// 
-        /// RenewFilteredProxies(0, "JP", true);
-        /// // Renews a list of proxies from all countries except Japan.
-		///
-		/// RenewFilteredProxies(1, "80", false);
-        /// // Renews a list of proxies with only port 80.
-		///
-		/// RenewFilteredProxies(2, "US", false, "80", false)
-		/// // Renews a list of proxies from US only, with port 80.
-        /// </example>
-        public static void RenewFilteredProxies(int filterType, string value1, bool exclude1, string value2, bool exclude2)
+        /// <param name="value">The country code used to filter. (e.g : US)</param>
+        /// <param name="exclude">True for include only value; False to exlude value,</param>
+        public static void FilterQueueByCountry(string value, bool exclude)
         {
             usedProxies.AddRange(queue);
             queue.Clear();
-            queue = Scrape.ScrapeFilteredProxy(filterType, value1, exclude1, value2, exclude2);
+
+            Scrape.FilterProxiesDataTableByCountry(value, exclude);
+            queue = Scrape.ReturnAllProxy();
+        }
+
+        /// <summary>
+        /// This method filters the proxies by port. Include only or exclude proxies that match filter.
+        /// </summary>
+        /// <param name="value">The port used to filter. (e.g : 80)</param>
+        /// <param name="exclude">True for include only value; False to exlude value.</param>
+        public static void FilterQueueByPort(string value, bool exclude)
+        {
+            usedProxies.AddRange(queue);
+            queue.Clear();
+
+            Scrape.FilterProxiesDataTableByPort(value, exclude);
+            queue = Scrape.ReturnAllProxy();
+        }
+
+        /// <summary>
+        /// This method filters the proxies by anonymity level. Include only or exclude proxies that match filter.
+        /// </summary>
+        /// <param name="value">The level of anonymity used to filter; (1 = elite proxy, 2 = anonymous, 3 = transparent)</param>
+        /// <param name="exclude">True for include only value; False to exlude value.</param>
+        public static void FilterQueueByAnonymityLevel(int value, bool exclude)
+        {
+            usedProxies.AddRange(queue);
+            queue.Clear();
+
+            Scrape.FilterProxiesDataTableByAnonymity(value, exclude);
+            queue = Scrape.ReturnAllProxy();
+        }
+
+        /// <summary>
+        /// This method filters the proxies by https. Include only or exclude proxies that match filter.
+        /// </summary>
+        /// <param name="value">True = Https, False = Http</param>
+        /// <param name="exclude">True for include only value; False to exlude value</param>
+        public static void FilterQueueByHttps(bool value, bool exclude)
+        {
+            usedProxies.AddRange(queue);
+            queue.Clear();
+
+            Scrape.FilterProxiesDataTableByHttps(value, exclude);
+            queue = Scrape.ReturnAllProxy();
         }
 
         /// <summary>

--- a/ProxySharp/Proxy.cs
+++ b/ProxySharp/Proxy.cs
@@ -89,56 +89,56 @@ namespace ProxySharp
         /// <summary>
         /// This method filters the proxies by country code. Include only or exclude proxies that match filter.
         /// </summary>
-        /// <param name="value">The country code used to filter. (e.g : US)</param>
+        /// <param name="filter">The country code used to filter. (e.g : US)</param>
         /// <param name="exclude">True for include only value; False to exlude value,</param>
-        public static void FilterQueueByCountry(string value, bool exclude)
+        public static void FilterQueueByCountry(string filter, bool exclude)
         {
             usedProxies.AddRange(queue);
             queue.Clear();
 
-            Scrape.FilterProxiesDataTableByCountry(value, exclude);
+            Scrape.FilterProxiesDataTableByCountry(filter, exclude);
             queue = Scrape.ReturnAllProxy();
         }
 
         /// <summary>
         /// This method filters the proxies by port. Include only or exclude proxies that match filter.
         /// </summary>
-        /// <param name="value">The port used to filter. (e.g : 80)</param>
+        /// <param name="filter">The port used to filter. (e.g : 80)</param>
         /// <param name="exclude">True for include only value; False to exlude value.</param>
-        public static void FilterQueueByPort(string value, bool exclude)
+        public static void FilterQueueByPort(string filter, bool exclude)
         {
             usedProxies.AddRange(queue);
             queue.Clear();
 
-            Scrape.FilterProxiesDataTableByPort(value, exclude);
+            Scrape.FilterProxiesDataTableByPort(filter, exclude);
             queue = Scrape.ReturnAllProxy();
         }
 
         /// <summary>
         /// This method filters the proxies by anonymity level. Include only or exclude proxies that match filter.
         /// </summary>
-        /// <param name="value">The level of anonymity used to filter; (1 = elite proxy, 2 = anonymous, 3 = transparent)</param>
+        /// <param name="filter">The level of anonymity used to filter; (1 = elite proxy, 2 = anonymous, 3 = transparent)</param>
         /// <param name="exclude">True for include only value; False to exlude value.</param>
-        public static void FilterQueueByAnonymityLevel(int value, bool exclude)
+        public static void FilterQueueByAnonymityLevel(int filter, bool exclude)
         {
             usedProxies.AddRange(queue);
             queue.Clear();
 
-            Scrape.FilterProxiesDataTableByAnonymity(value, exclude);
+            Scrape.FilterProxiesDataTableByAnonymity(filter, exclude);
             queue = Scrape.ReturnAllProxy();
         }
 
         /// <summary>
         /// This method filters the proxies by https. Include only or exclude proxies that match filter.
         /// </summary>
-        /// <param name="value">True = Https, False = Http</param>
+        /// <param name="filter">True = Https, False = Http</param>
         /// <param name="exclude">True for include only value; False to exlude value</param>
-        public static void FilterQueueByHttps(bool value, bool exclude)
+        public static void FilterQueueByHttps(bool filter, bool exclude)
         {
             usedProxies.AddRange(queue);
             queue.Clear();
 
-            Scrape.FilterProxiesDataTableByHttps(value, exclude);
+            Scrape.FilterProxiesDataTableByHttps(filter, exclude);
             queue = Scrape.ReturnAllProxy();
         }
 

--- a/ProxySharp/ProxySharp.csproj
+++ b/ProxySharp/ProxySharp.csproj
@@ -10,10 +10,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/m-henderson/ProxySharp</RepositoryUrl>
     <PackageTags>proxy; server</PackageTags>
-    <Version>2.0.0.0</Version>
+    <Version>2.0.1</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <FileVersion>2.0.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProxySharp/Scrape.cs
+++ b/ProxySharp/Scrape.cs
@@ -161,7 +161,7 @@ namespace ProxySharp
         /// </summary>
         /// <param name="filter">The country code filter</param>
         /// <param name="exclude">Bool used to determine if the proxies that match the filter should be included or excluded.</param>
-        public static void FilterProxiesDataTableByCountry(string filter, bool exclude)
+        internal static void FilterProxiesDataTableByCountry(string filter, bool exclude)
         {
             List<int> IndexesList = new List<int>();
 
@@ -240,7 +240,7 @@ namespace ProxySharp
         /// <param name="filter"></param>
         /// <param name="exclude"></param>
         /// <returns></returns>
-        public static void FilterProxiesDataTableByAnonymity(int filter, bool exclude)
+        internal static void FilterProxiesDataTableByAnonymity(int filter, bool exclude)
         {
             List<int> IndexesList = new List<int>();
 
@@ -279,7 +279,7 @@ namespace ProxySharp
         /// </summary>
         /// <param name="filter"></param>
         /// <param name="exclude"></param>
-        public static void FilterProxiesDataTableByHttps(bool filter, bool exclude)
+        internal static void FilterProxiesDataTableByHttps(bool filter, bool exclude)
         {
             List<int> IndexesList = new List<int>();
 
@@ -317,7 +317,7 @@ namespace ProxySharp
         /// Method to add all proxies to the queue whitout filtering.
         /// </summary>
         /// <returns>A list a proxies</returns>
-        public static List<string> ReturnAllProxy()
+        internal static List<string> ReturnAllProxy()
         {
             var proxyQueue = new List<string>();
 

--- a/ProxySharp/Scrape.cs
+++ b/ProxySharp/Scrape.cs
@@ -13,13 +13,13 @@ namespace ProxySharp
         /// <summary>
         /// The queue that holds all of the proxies data returned from the scraper
         /// </summary>
-        private static List<(string, string, string, int, bool)> ProxiesDataTable = new List<(string, string, string, int, bool)>();
+        private static readonly List<(string, string, string, int, bool)> ProxiesDataTable = new List<(string, string, string, int, bool)>();
 
         /// <summary>
         /// Scrapes the proxy data from the website.
         /// </summary>
         /// <returns>A list of tuples that contain the proxy, country code, and port.</returns>
-        public static void GatherProxiesData()
+        internal static void GatherProxiesData()
         {
             string url = "https://free-proxy-list.net/";
             HtmlWeb hw = new HtmlWeb();
@@ -159,17 +159,18 @@ namespace ProxySharp
         /// <summary>
         /// Method to filter the proxies by country code. Include only or exclude proxies that match filter.
         /// </summary>
-        /// <param name="value">The country code filter</param>
+        /// <param name="filter">The country code filter</param>
         /// <param name="exclude">Bool used to determine if the proxies that match the filter should be included or excluded.</param>
-        public static void FilterProxiesDataTableByCountry(string value, bool exclude)
+        public static void FilterProxiesDataTableByCountry(string filter, bool exclude)
         {
             List<int> IndexesList = new List<int>();
+
             switch (exclude)
             {
                 case false:
                     foreach (var item in ProxiesDataTable)
                     {
-                        if (item.Item2 != value)
+                        if (item.Item2 != filter)
                         {
                             IndexesList.Add(ProxiesDataTable.IndexOf(item));
                         }
@@ -179,7 +180,7 @@ namespace ProxySharp
                 case true:
                     foreach (var item in ProxiesDataTable)
                     {
-                        if (item.Item2 == value)
+                        if (item.Item2 == filter)
                         {
                             IndexesList.Add(ProxiesDataTable.IndexOf(item));
                         }
@@ -197,17 +198,18 @@ namespace ProxySharp
         /// <summary>                
         /// Method to filter the proxies by port. Include only or exclude proxies that match filter.
         /// </summary>
-        /// <param name="value">The port filter</param>
+        /// <param name="filter">The port filter</param>
         /// <param name="exclude">Bool used to determine if the proxies that match the filter should be included or excluded.</param>
-        public static void FilterProxiesDataTableByPort(string value, bool exclude)
+        public static void FilterProxiesDataTableByPort(string filter, bool exclude)
         {
             List<int> IndexesList = new List<int>();
+
             switch (exclude)
             {
                 case false:
                     foreach (var item in ProxiesDataTable)
                     {
-                        if (item.Item3 != value)
+                        if (item.Item3 != filter)
                         {
                             IndexesList.Add(ProxiesDataTable.IndexOf(item));
                         }
@@ -217,7 +219,7 @@ namespace ProxySharp
                 case true:
                     foreach (var item in ProxiesDataTable)
                     {
-                        if (item.Item3 == value)
+                        if (item.Item3 == filter)
                         {
                             IndexesList.Add(ProxiesDataTable.IndexOf(item));
                         }
@@ -235,18 +237,19 @@ namespace ProxySharp
         /// <summary>
         /// This method filters the proxies by anonymity level. Include only or exclude proxies that match filter.
         /// </summary>
-        /// <param name="value"></param>
+        /// <param name="filter"></param>
         /// <param name="exclude"></param>
         /// <returns></returns>
-        public static void FilterProxiesDataTableByAnonymity(int value, bool exclude)
+        public static void FilterProxiesDataTableByAnonymity(int filter, bool exclude)
         {
             List<int> IndexesList = new List<int>();
+
             switch (exclude)
             {
                 case false:
                     foreach (var item in ProxiesDataTable)
                     {
-                        if (item.Item4 != value)
+                        if (item.Item4 != filter)
                         {
                             IndexesList.Add(ProxiesDataTable.IndexOf(item));
                         }
@@ -256,14 +259,14 @@ namespace ProxySharp
                 case true:
                     foreach (var item in ProxiesDataTable)
                     {
-                        if (item.Item4 == value)
+                        if (item.Item4 == filter)
                         {
                             IndexesList.Add(ProxiesDataTable.IndexOf(item));
                         }
                     }
                     break;
             }
-
+            
             IndexesList.Reverse(); // Reverse the list to avoid index out of range error.
             foreach (var index in IndexesList)
             {
@@ -271,15 +274,21 @@ namespace ProxySharp
             }
         }
 
-        public static void FilterProxiesDataTableByHttps(bool value, bool exclude)
+        /// <summary>
+        /// This method filters the proxies by https. Include only or exclude proxies that match filter.
+        /// </summary>
+        /// <param name="filter"></param>
+        /// <param name="exclude"></param>
+        public static void FilterProxiesDataTableByHttps(bool filter, bool exclude)
         {
             List<int> IndexesList = new List<int>();
+
             switch (exclude)
             {
                 case false:
                     foreach (var item in ProxiesDataTable)
                     {
-                        if (item.Item5 != value)
+                        if (item.Item5 != filter)
                         {
                             IndexesList.Add(ProxiesDataTable.IndexOf(item));
                         }
@@ -289,7 +298,7 @@ namespace ProxySharp
                 case true:
                     foreach (var item in ProxiesDataTable)
                     {
-                        if (item.Item5 == value)
+                        if (item.Item5 == filter)
                         {
                             IndexesList.Add(ProxiesDataTable.IndexOf(item));
                         }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install-Package ProxySharp -Version 2.0.1
 - `PopProxy()` : Removes the first proxy in the queue.
 
 ## Specifications
-- All functions use a list of tuples from `Scrape.cs`. This list store all data related to the proxies.
+- All functions for filtering and renew uses a list of tuples from `Scrape.cs`. This list store all data related to the proxies. These proxies in `queue` are extracted from that list. 
 - `RenewQueue()` is the only function that renew this list of tuples, so it is the only way to get fresh proxies or remove applied filters.
 - `FilterQueueByXXX()` does not renew the list of tuples, it only filters the actual queue with the criteria. Allow to chain multiple filters.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In the usage example below we make a post request look like it is coming from an
 ---
 ## Install
 ```
-Install-Package ProxySharp -Version 2.0.0.0
+Install-Package ProxySharp -Version 2.0.1
 ```
 ## Functions
 - `GetProxies()` : Gets a list of proxies that are currently in the queue.
@@ -16,10 +16,19 @@ Install-Package ProxySharp -Version 2.0.0.0
 - `GetSingleRandomProxy()` : Gets a single randomly choosed proxy from the queue.
 - `GetUsedProxies()` :  Gets a list of previously used proxies. The lower the index, the older the proxy.
 - `RenewQueue()` : Clears the queue then adds a fresh list of proxies to the queue.
-- `RenewFilteredProxies(int filterType, string value1, bool exclude1, string value2, bool exclude2)` : Clears the queue, then adds a fresh, filtered list of proxies based on the specified filters. Allows filtering by or excluding proxies. When "filterType = 2", the value1 and exclude1 are used for County and value2 and exclude2 for Port.
+- `FilterQueueByCountry(string value, bool exclude)` : Filter the actual queue by country based on given values.
+- `FilterQueueByPort(string value, bool exclude)` : Filter the actual queue by anonymity based on given values.
+- `FilterQueueByAnonymityLevel(int value, bool exclude)` : Filter the actual queue by anonymity level based on given values.
+- `FilterQueueByHttps(bool value, bool exclude)` : Filter the actual queue by Https support based on given values.
 - `GetIndex(string proxy)` : Gets the index of a proxy.
 - `AddProxy(string ip, string port)` : Adds the specified proxy to the queue.
 - `PopProxy()` : Removes the first proxy in the queue.
+
+## Specifications
+- All functions use a list of tuples from `Scrape.cs`. This list store all data related to the proxies.
+- `RenewQueue()` is the only function that renew this list of tuples, so it is the only way to get fresh proxies or remove applied filters.
+- `FilterQueueByXXX()` does not renew the list of tuples, it only filters the actual queue with the criteria. Allow to chain multiple filters.
+
 ## Dependencies
 - [HtmlAgilityPack](https://www.nuget.org/packages/HtmlAgilityPack/) [v1.11.62]
 - [NETStandard.Library](https://www.nuget.org/packages/NETStandard.Library) [v2.0.3]


### PR DESCRIPTION
## Purpose :
- Fix #14 
- Fix #20 
- Fix #21 

## Details :
- Updated ProxySharp to version 2.0.1.
- Introducing new methods for filtering proxies by country, port, anonymity level, and HTTPS support.
- Removed the `RenewFilteredProxies` method and replaced it with more specific filtering methods. Allow to chain multiple filters.
- Updated `Scrape` methods and added a private list `ProxiesDataTable` to store proxy data.
- Updated `README.md` to reflect these changes and added a new "Specifications" section.
- Renamed parameter `value` to `filter` in `Proxy.cs` and `Scrape.cs`
- Made `ProxiesDataTable` readonly in `Scrape.cs`
- Changed `GatherProxiesData` and others methods visibility to internal in `Proxy.cs`.
- Updated comments and summaries for clarity